### PR TITLE
Set up CI caching 

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,11 +9,11 @@ jobs:
     - uses: actions/checkout@v2
     - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: false
-    - name: Build the shared image
+    - name: Build colonists-shared
       run: docker build --tag colonists/colonists-shared:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-shared
-    - name: Build the server
+    - name: Build colonists-server
       run: docker build --tag colonists/colonists-server:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-server
-    - name: Build the client
+    - name: Build colonists-client
       run: docker build --tag colonists/colonists-client:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-client
     - name: Run tests
       run: docker run --rm colonists/colonists-shared:$(git log --pretty=format:'%h' -n 1)

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,5 +15,5 @@ jobs:
       run: docker build --tag colonists/colonists-server:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-server
     - name: Build colonists-client
       run: docker build --tag colonists/colonists-client:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-client
-    - name: Run tests
+    - name: Run shared tests
       run: docker run --rm colonists/colonists-shared:$(git log --pretty=format:'%h' -n 1)

--- a/colonists-client/Dockerfile
+++ b/colonists-client/Dockerfile
@@ -2,29 +2,36 @@
 ARG BRANCH_TAG=latest
 FROM colonists/colonists-shared:${BRANCH_TAG} as library
 
+# Cache
+FROM node:alpine as dependency-cache-client
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh python3 make g++
+WORKDIR /cache
+COPY ./package*.json ./
+#     --legacy-peer-deps is needed for Vue 2
+RUN npm install --legacy-peer-deps 
+
 # Builder
 FROM node:alpine as builder
 # Global dependencies
+RUN ["npm", "install", "-g", "typescript"]
 RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh
+    apk add --no-cache bash git openssh python3 make g++
 
 WORKDIR /app
 # Copy over library
 COPY --from=library /app /app/colonists-shared
 
 # App dependencies
-RUN ["npm", "install", "-g", "typescript"]
 WORKDIR /app/client
-
-# Install Dependencies
+COPY --from=dependency-cache-client /cache/node_modules ./node_modules
 COPY ./package*.json ./
-COPY .yarnrc.yml ./
-COPY .yarn/releases/yarn-berry.cjs ./.yarn/releases/yarn-berry.cjs
-RUN yarn install
+#     --legacy-peer-deps is needed for Vue 2
+RUN npm install --legacy-peer-deps
 
 # Build app
 COPY . .
-RUN yarn build
+RUN npm run build
 
 # Runtime image
 FROM nginx:alpine

--- a/colonists-client/yarn.lock
+++ b/colonists-client/yarn.lock
@@ -4865,11 +4865,11 @@ __metadata:
 
 "colonists-shared@file:../colonists-shared::locator=colonists-client%40workspace%3A.":
   version: 1.0.0
-  resolution: "colonists-shared@file:../colonists-shared#../colonists-shared::hash=b964f2&locator=colonists-client%40workspace%3A."
+  resolution: "colonists-shared@file:../colonists-shared#../colonists-shared::hash=b73f57&locator=colonists-client%40workspace%3A."
   dependencies:
     honeycomb-grid: ^3.1.7
     uuid: ^8.3.2
-  checksum: bd27b0276743b077caa2c333f6c8522c16571071077483093d2d9649ea6d2b3050983155c404ae0c50464cd12a0195ce80cfe69fb5ec7e008186ada1ca241f30
+  checksum: 31a2da541e2acf37e98bcadc4c31c9ad2090701d2991821c425ec0dcfdc8b355e37dfc756831a876d8810a276c5e0625a931ad20974b0f80dadbfb4cb84a79c4
   languageName: node
   linkType: hard
 

--- a/colonists-server/Dockerfile
+++ b/colonists-server/Dockerfile
@@ -1,7 +1,12 @@
 ARG BRANCH_TAG=latest
 FROM colonists/colonists-shared:${BRANCH_TAG} as library
 
-FROM node:alpine
+FROM node as dependency-cache-server
+WORKDIR /cache
+COPY package*.json ./
+RUN npm install
+
+FROM node
 WORKDIR /app
 # Copy over library
 COPY --from=library /app /app/colonists-shared
@@ -9,16 +14,15 @@ COPY --from=library /app /app/colonists-shared
 # App dependencies
 RUN ["npm", "install", "-g", "typescript"]
 WORKDIR /app/server
-COPY package.json ./
-COPY .yarnrc.yml ./
-COPY .yarn/releases/yarn-berry.cjs ./.yarn/releases/yarn-berry.cjs
-RUN yarn install
+COPY --from=dependency-cache-server /cache/node_modules ./node_modules
+COPY package*.json ./
+RUN npm install
 
 # Build app
 COPY . .
-RUN yarn build
+RUN npm run build
 
 # Run
 ENV PORT 3000
 EXPOSE 3000
-CMD ["yarn", "start"]
+CMD ["npm", "run", "start"]

--- a/colonists-server/yarn.lock
+++ b/colonists-server/yarn.lock
@@ -614,11 +614,11 @@ __metadata:
 
 "colonists-shared@file:../colonists-shared::locator=colonists-server%40workspace%3A.":
   version: 1.0.0
-  resolution: "colonists-shared@file:../colonists-shared#../colonists-shared::hash=af634c&locator=colonists-server%40workspace%3A."
+  resolution: "colonists-shared@file:../colonists-shared#../colonists-shared::hash=b73f57&locator=colonists-server%40workspace%3A."
   dependencies:
     honeycomb-grid: ^3.1.7
     uuid: ^8.3.2
-  checksum: fa8eb542cbb9725f6a069e5006377f75332a1f04bd0cfdf852cc0855b6960f312cd1cf044819507fd958e951e2d0a2610f7de2fae6e9bc350769e146e53cf622
+  checksum: 31a2da541e2acf37e98bcadc4c31c9ad2090701d2991821c425ec0dcfdc8b355e37dfc756831a876d8810a276c5e0625a931ad20974b0f80dadbfb4cb84a79c4
   languageName: node
   linkType: hard
 

--- a/colonists-shared/Dockerfile
+++ b/colonists-shared/Dockerfile
@@ -1,15 +1,20 @@
 ARG BRANCH_TAG=latest
-FROM node:latest
+FROM node as dependency-cache-shared
+WORKDIR /cache
+COPY package*.json ./
+RUN npm install
+
+FROM node
 WORKDIR /app
 
 # App dependencies
 RUN ["npm", "install", "-g", "typescript"]
-COPY package.json ./
-COPY .yarnrc.yml ./
-COPY .yarn/releases/yarn-berry.cjs ./.yarn/releases/yarn-berry.cjs
-RUN ["yarn", "install"]
+
+COPY --from=dependency-cache-shared /cache/node_modules ./node_modules
+COPY package.json package-lock.json ./
+RUN ["npm", "install"]
 
 COPY . /app
 
-RUN ["yarn", "build"]
-CMD ["yarn", "test"]
+RUN ["npm", "run", "build"]
+CMD ["npm", "run", "test"]


### PR DESCRIPTION
This will: 
- modify CI runs to use `npm` instead of `yarn` (caching in `yarn` is a nightmare to set up, I tried) 
- add creation of intermediate docker images for caching (these _should_ be cached by the `action-docker-layer-caching` action) 
- modify orders of Dockerfile statements to improve caching slightly